### PR TITLE
add EXPIRE, TTL, PERSIST, cache cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ set name sojeb
 # Supported commands
 - PING
 - SET
+  - Support EX argument
 - GET
 - HSET
 - HGET
@@ -38,3 +39,7 @@ set name sojeb
 - INFO
 - INCR
 - DECR
+
+- EXPIRE
+- TTL
+- PERSIST

--- a/internal/server.go
+++ b/internal/server.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"fmt"
 	"net"
-	"os"
 	"path/filepath"
 	"strings"
 )
@@ -25,18 +24,18 @@ func StartServer() {
 	}
 	defer listener.Close()
 
-	exePath, err := os.Executable()
-	if err != nil {
-		panic(err)
-	}
-
+	// exePath, err := os.Executable()
+	// if err != nil {
+	// 	panic(err)
+	// }
 	// Resolve symlinks and get absolute directory
-	exePath, err = filepath.EvalSymlinks(exePath)
-	if err != nil {
-		panic(err)
-	}
+	// exePath, err = filepath.EvalSymlinks(exePath)
+	// if err != nil {
+	// 	panic(err)
+	// }
+	// path := filepath.Join(filepath.Dir(exePath), "database.aof")
 
-	path := filepath.Join(filepath.Dir(exePath), "database.aof")
+	path := filepath.Join("database.aof")
 	aof, err := NewAof(path)
 	if err != nil {
 		fmt.Println("Error opening AOF:", err)
@@ -57,6 +56,9 @@ func StartServer() {
 
 		handler(args)
 	})
+
+	// Start the background key expiry cleaner
+	StartKeyExpiryCleaner()
 
 	for {
 		conn, err := listener.Accept()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SET command now supports the EX argument to specify key expiration times.
  * Added EXPIRE command to set or update key expiration.
  * Added TTL command to retrieve remaining time-to-live for keys.
  * Added PERSIST command to remove expiration from keys.
  * Automatic background cleanup of expired keys.

* **Documentation**
  * Updated README with new commands and SET EX argument support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->